### PR TITLE
non-static getServices that returns callables

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,8 +143,8 @@ that gets access to the object instance and the container.
 
 Simplex supports registering [cross-framework service providers](https://github.com/container-interop/service-provider).
 
-To register one, call the `register()` method and pass the class name of the service provider:
+To register one, call the `register()` method and pass the service provider instance:
 
 ```php
-$container->register(MyServiceProvider::class);
+$container->register(new MyServiceProvider());
 ```

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.0",
         "container-interop/container-interop": "^1.0",
-        "container-interop/service-provider": "~0.2.0"
+        "container-interop/service-provider": "~0.3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"

--- a/src/Simplex/Container.php
+++ b/src/Simplex/Container.php
@@ -29,6 +29,7 @@ namespace Simplex;
 use Interop\Container\ContainerInterface;
 use Interop\Container\Exception\ContainerException;
 use Interop\Container\Exception\NotFoundException;
+use Interop\Container\ServiceProvider;
 use Simplex\Exception\EntryNotFound;
 
 /**
@@ -305,14 +306,14 @@ class Container implements \ArrayAccess, ContainerInterface
     /**
      * Registers a service provider.
      *
-     * @param string $provider Name of a class implementing the ServiceProvider interface
+     * @param ServiceProvider $provider the service provider to register
      * @param array $values An array of values that customizes the provider
      *
      * @return static
      */
-    public function register($provider, array $values = array())
+    public function register(ServiceProvider $provider, array $values = array())
     {
-        $entries = call_user_func(array($provider, 'getServices'));
+        $entries = $provider->getServices();
 
         foreach ($entries as $key => $callable) {
 

--- a/src/Simplex/Container.php
+++ b/src/Simplex/Container.php
@@ -314,8 +314,7 @@ class Container implements \ArrayAccess, ContainerInterface
     {
         $entries = call_user_func(array($provider, 'getServices'));
 
-        foreach ($entries as $key => $method) {
-            $callable = array($provider, $method);
+        foreach ($entries as $key => $callable) {
 
             if (isset($this->keys[$key])) {
                 // Extend a previous entry

--- a/src/Simplex/Tests/ContainerTest.php
+++ b/src/Simplex/Tests/ContainerTest.php
@@ -27,6 +27,7 @@
 namespace Simplex\Tests;
 
 use Simplex\Container;
+use Simplex\Tests\Fixtures\SimplexServiceProvider;
 
 /**
  * @author  Igor Wiedler <igor@wiedler.ch>
@@ -187,7 +188,7 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
     public function testFluentRegister()
     {
         $pimple = new Container();
-        $this->assertSame($pimple, $pimple->register('Simplex\Tests\Fixtures\SimplexServiceProvider'));
+        $this->assertSame($pimple, $pimple->register(new SimplexServiceProvider()));
     }
 
     /**

--- a/src/Simplex/Tests/Fixtures/SimplexServiceProvider.php
+++ b/src/Simplex/Tests/Fixtures/SimplexServiceProvider.php
@@ -1,29 +1,4 @@
 <?php
-
-/*
- * This file is part of Pimple.
- *
- * Copyright (c) 2009 Fabien Potencier
- *
- * Permission is hereby granted, free of charge, to any person obtaining a copy
- * of this software and associated documentation files (the "Software"), to deal
- * in the Software without restriction, including without limitation the rights
- * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- * copies of the Software, and to permit persons to whom the Software is furnished
- * to do so, subject to the following conditions:
- *
- * The above copyright notice and this permission notice shall be included in all
- * copies or substantial portions of the Software.
- *
- * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
- * THE SOFTWARE.
- */
-
 namespace Simplex\Tests\Fixtures;
 
 use Interop\Container\ContainerInterface;
@@ -34,11 +9,11 @@ class SimplexServiceProvider implements ServiceProvider
     public static function getServices()
     {
         return array(
-            'param' => [SimplexServiceProvider::class, 'getParam'],
+            'param' => array(SimplexServiceProvider::class, 'getParam'),
             'service' => function() {
                 return new Service();
             },
-            'previous' => [SimplexServiceProvider::class, 'getPrevious'],
+            'previous' => array(SimplexServiceProvider::class, 'getPrevious'),
         );
     }
 

--- a/src/Simplex/Tests/Fixtures/SimplexServiceProvider.php
+++ b/src/Simplex/Tests/Fixtures/SimplexServiceProvider.php
@@ -6,7 +6,7 @@ use Interop\Container\ServiceProvider;
 
 class SimplexServiceProvider implements ServiceProvider
 {
-    public static function getServices()
+    public function getServices()
     {
         return array(
             'param' => array(SimplexServiceProvider::class, 'getParam'),

--- a/src/Simplex/Tests/Fixtures/SimplexServiceProvider.php
+++ b/src/Simplex/Tests/Fixtures/SimplexServiceProvider.php
@@ -34,20 +34,17 @@ class SimplexServiceProvider implements ServiceProvider
     public static function getServices()
     {
         return array(
-            'param' => 'getParam',
-            'service' => 'getService',
-            'previous' => 'getPrevious',
+            'param' => [SimplexServiceProvider::class, 'getParam'],
+            'service' => function() {
+                return new Service();
+            },
+            'previous' => [SimplexServiceProvider::class, 'getPrevious'],
         );
     }
 
     public static function getParam()
     {
         return 'value';
-    }
-
-    public static function getService()
-    {
-        return new Service();
     }
 
     public static function getPrevious(ContainerInterface $container, callable $getPrevious = null)

--- a/src/Simplex/Tests/ServiceProviderTest.php
+++ b/src/Simplex/Tests/ServiceProviderTest.php
@@ -27,6 +27,7 @@
 namespace Simplex\Tests;
 
 use Simplex\Container;
+use Simplex\Tests\Fixtures\SimplexServiceProvider;
 
 /**
  * @author Dominik Zogg <dominik.zogg@gmail.com>
@@ -38,7 +39,7 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
     {
         $pimple = new Container();
 
-        $pimple->register('Simplex\Tests\Fixtures\SimplexServiceProvider');
+        $pimple->register(new SimplexServiceProvider());
 
         $this->assertEquals('value', $pimple['param']);
         $this->assertInstanceOf('Simplex\Tests\Fixtures\Service', $pimple['service']);
@@ -48,7 +49,7 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
     {
         $pimple = new Container();
 
-        $pimple->register('Simplex\Tests\Fixtures\SimplexServiceProvider', array(
+        $pimple->register(new SimplexServiceProvider(), array(
             'anotherParameter' => 'anotherValue',
         ));
 
@@ -62,7 +63,7 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
     {
         $pimple = new Container();
         $pimple['previous'] = 'foo';
-        $pimple->register('Simplex\Tests\Fixtures\SimplexServiceProvider');
+        $pimple->register(new SimplexServiceProvider());
         $getPrevious = $pimple['previous'];
         $this->assertEquals('foo', $getPrevious());
     }
@@ -70,7 +71,7 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
     public function testExtendingNothing()
     {
         $pimple = new Container();
-        $pimple->register('Simplex\Tests\Fixtures\SimplexServiceProvider');
+        $pimple->register(new SimplexServiceProvider());
         $this->assertNull($pimple['previous']);
     }
 }


### PR DESCRIPTION
This is just a small PR to show the code impact of using service providers that return "callables" instead of "function names".
