### PR TITLE
Adding set/delete methods for symmetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,8 @@ Simplex is a fork of Pimple's code. The only differences are the following:
 - `Simplex\Container` implements [`ContainerInterface`](https://github.com/container-interop/container-interop/blob/master/src/Interop/Container/ContainerInterface.php), which means the following methods exist:
     - `$container->get($id)` which is an alias to `$container[$id]`
     - `$container->has($id)` which is an alias to `isset($container[$id])`
-- for symmetry reasons, `Simplex\Container` also provides to additional methods:
+- for symmetry reasons, `Simplex\Container` also provides an additional method:
     - `$container->set($id, $value)` which is an alias to `$container[$id] = ...`
-    - `$container->delete($id)` which is an alias to `unset($container[$id])`
 - the constructor takes an optional `ContainerInterface $rootContainer = null` argument to support the [delegate lookup feature](https://github.com/container-interop/container-interop/blob/master/docs/Delegate-lookup.md): if provided, this container will be injected in factories instead
 - service providers have been completely replaced by [container-interop's service providers](https://github.com/container-interop/service-provider): that allows to load cross-framework modules in this container
 - it is possible to extend a scalar value with `$container->extend()` (for compatibility reasons with cross-framework service providers)

--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Simplex is a fork of Pimple's code. The only differences are the following:
 - `Simplex\Container` implements [`ContainerInterface`](https://github.com/container-interop/container-interop/blob/master/src/Interop/Container/ContainerInterface.php), which means the following methods exist:
     - `$container->get($id)` which is an alias to `$container[$id]`
     - `$container->has($id)` which is an alias to `isset($container[$id])`
+- for symmetry reasons, `Simplex\Container` also provides to additional methods:
+    - `$container->set($id, $value)` which is an alias to `$container[$id] = ...`
+    - `$container->delete($id)` which is an alias to `unset($container[$id])`
 - the constructor takes an optional `ContainerInterface $rootContainer = null` argument to support the [delegate lookup feature](https://github.com/container-interop/container-interop/blob/master/docs/Delegate-lookup.md): if provided, this container will be injected in factories instead
 - service providers have been completely replaced by [container-interop's service providers](https://github.com/container-interop/service-provider): that allows to load cross-framework modules in this container
 - it is possible to extend a scalar value with `$container->extend()` (for compatibility reasons with cross-framework service providers)

--- a/src/Simplex/Container.php
+++ b/src/Simplex/Container.php
@@ -122,16 +122,6 @@ class Container implements \ArrayAccess, ContainerInterface
     }
 
     /**
-     * Unsets a parameter or an object.
-     *
-     * @param string $id The unique identifier for the parameter or object
-     */
-    public function delete($id)
-    {
-        $this->offsetUnset($id);
-    }
-
-    /**
      * Sets a parameter or an object.
      *
      * Objects must be defined as Closures.

--- a/src/Simplex/Container.php
+++ b/src/Simplex/Container.php
@@ -116,6 +116,35 @@ class Container implements \ArrayAccess, ContainerInterface
      *
      * @throws \RuntimeException Prevent override of a frozen service
      */
+    public function set($id, $value)
+    {
+        $this->offsetSet($id, $value);
+    }
+
+    /**
+     * Unsets a parameter or an object.
+     *
+     * @param string $id The unique identifier for the parameter or object
+     */
+    public function delete($id)
+    {
+        $this->offsetUnset($id);
+    }
+
+    /**
+     * Sets a parameter or an object.
+     *
+     * Objects must be defined as Closures.
+     *
+     * Allowing any PHP callable leads to difficult to debug problems
+     * as function names (strings) are callable (creating a function with
+     * the same name as an existing parameter would break your container).
+     *
+     * @param string $id    The unique identifier for the parameter or object
+     * @param mixed  $value The value of the parameter or a closure to define an object
+     *
+     * @throws \RuntimeException Prevent override of a frozen service
+     */
     public function offsetSet($id, $value)
     {
         if (isset($this->frozen[$id])) {

--- a/src/Simplex/Tests/ContainerTest.php
+++ b/src/Simplex/Tests/ContainerTest.php
@@ -478,4 +478,21 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame($root, $container['self']);
     }
+
+    public function testSet()
+    {
+        $pimple = new Container();
+        $pimple->set('param', 'value');
+
+        $this->assertEquals('value', $pimple['param']);
+    }
+
+    public function testDelete()
+    {
+        $pimple = new Container();
+        $pimple['param'] = 'value';
+
+        $pimple->delete('param');
+        $this->assertFalse(isset($pimple['param']));
+    }
 }

--- a/src/Simplex/Tests/ContainerTest.php
+++ b/src/Simplex/Tests/ContainerTest.php
@@ -486,13 +486,4 @@ class ContainerTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals('value', $pimple['param']);
     }
-
-    public function testDelete()
-    {
-        $pimple = new Container();
-        $pimple['param'] = 'value';
-
-        $pimple->delete('param');
-        $this->assertFalse(isset($pimple['param']));
-    }
 }


### PR DESCRIPTION
Closes #3 .
Note I also added a `delete`  method (also for symmetry with `unset`), even if this is really less used than `set`.
