### PR TITLE
Migrating to container-interop/service-provider 0.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.0",
         "container-interop/container-interop": "^1.0",
-        "container-interop/service-provider": "~0.3.0"
+        "container-interop/service-provider": "~0.4.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.0"

--- a/src/Simplex/Tests/Fixtures/SimplexServiceProvider.php
+++ b/src/Simplex/Tests/Fixtures/SimplexServiceProvider.php
@@ -3,16 +3,23 @@ namespace Simplex\Tests\Fixtures;
 
 use Interop\Container\ContainerInterface;
 use Interop\Container\ServiceProvider;
+use Interop\Container\ServiceProviderInterface;
 
-class SimplexServiceProvider implements ServiceProvider
+class SimplexServiceProvider implements ServiceProviderInterface
 {
-    public function getServices()
+    public function getFactories()
     {
         return array(
             'param' => array(SimplexServiceProvider::class, 'getParam'),
             'service' => function() {
                 return new Service();
             },
+        );
+    }
+
+    public function getExtensions()
+    {
+        return array(
             'previous' => array(SimplexServiceProvider::class, 'getPrevious'),
         );
     }
@@ -22,8 +29,8 @@ class SimplexServiceProvider implements ServiceProvider
         return 'value';
     }
 
-    public static function getPrevious(ContainerInterface $container, callable $getPrevious = null)
+    public static function getPrevious(ContainerInterface $container, $previous = null)
     {
-        return $getPrevious;
+        return $previous.$previous;
     }
 }

--- a/src/Simplex/Tests/ServiceProviderTest.php
+++ b/src/Simplex/Tests/ServiceProviderTest.php
@@ -64,14 +64,14 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
         $pimple = new Container();
         $pimple['previous'] = 'foo';
         $pimple->register(new SimplexServiceProvider());
-        $getPrevious = $pimple['previous'];
-        $this->assertEquals('foo', $getPrevious());
+        $previous = $pimple['previous'];
+        $this->assertEquals('foofoo', $previous);
     }
 
     public function testExtendingNothing()
     {
         $pimple = new Container();
         $pimple->register(new SimplexServiceProvider());
-        $this->assertNull($pimple['previous']);
+        $this->assertSame('', $pimple['previous']);
     }
 }


### PR DESCRIPTION
This PR migrates Simplex to use the new [container-interop/service-provider 0.4 release](https://github.com/container-interop/service-provider/releases/tag/v0.4.0).

The migration is trivial enough. We simply perform 2 loops instead of one: one for `getFactories` and one for `getExtensions`.