### PR TITLE
Previous argument default value is always ignored

### DIFF
--- a/src/Simplex/Container.php
+++ b/src/Simplex/Container.php
@@ -356,7 +356,7 @@ class Container implements \ArrayAccess, ContainerInterface
                     });
                 } else {
                     $this[$key] = function (ContainerInterface $c) use ($callable) {
-                        return call_user_func($callable, $c, null);
+                        return call_user_func($callable, $c);
                     };
                 }
             }

--- a/src/Simplex/Tests/Fixtures/SimplexServiceProviderWithExtension.php
+++ b/src/Simplex/Tests/Fixtures/SimplexServiceProviderWithExtension.php
@@ -20,6 +20,11 @@ class SimplexServiceProviderWithExtension implements ServiceProviderInterface
                 return $previous . 'def';
 
             },
+            'extendNothing' => function ($container, string $previous = 'foo') {
+
+                return $previous . 'def';
+
+            },
         );
     }
 }

--- a/src/Simplex/Tests/ServiceProviderTest.php
+++ b/src/Simplex/Tests/ServiceProviderTest.php
@@ -73,4 +73,13 @@ class ServiceProviderTest extends \PHPUnit_Framework_TestCase
 
         $this->assertSame('abcdef', $pimple->get('test'));
     }
+
+    public function testExtensionWithNoFactory()
+    {
+        $pimple = new Container(array(
+            new SimplexServiceProviderWithExtension(),
+        ));
+
+        $this->assertSame('foodef', $pimple->get('extendNothing'));
+    }
 }


### PR DESCRIPTION
This PR contains right now only a failing test showing that there is a bug in the way we handle the "previous" default argument of extensions.

If there is no "previous" service, we expect the default value of the argument (if any) to be used. But Simplex always passes the "null" value as a second argument.