### PR TITLE
Making tests compatible with PHP 5.3+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ before_script:
   - composer install -n
 
 script:
-  - phpunit
+  - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: php
 
+# for PHP 5.3 compatibility
+dist: precise
+
 php:
   - 5.3
   - 5.4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,18 @@
 language: php
 
-# for PHP 5.3 compatibility
-dist: precise
-
 php:
-  - 5.3
   - 5.4
   - 5.5
   - 5.6
   - 7.0
   - 7.1
+  - 7.2
   - hhvm
+
+matrix:
+  include:
+    - php: 5.3
+      dist: precise
 
 before_script:
   - composer install -n

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/mnapoli/simplex.svg?branch=master)](https://travis-ci.org/mnapoli/simplex)
+
 # Simplex
 
 Simplex is a [Pimple 3](https://github.com/silexphp/Pimple) fork with full [container-interop](https://github.com/container-interop/container-interop) compliance and [cross-framework service-provider](https://github.com/container-interop/service-provider) support.

--- a/src/Simplex/Tests/Fixtures/SimplexServiceProvider.php
+++ b/src/Simplex/Tests/Fixtures/SimplexServiceProvider.php
@@ -10,7 +10,7 @@ class SimplexServiceProvider implements ServiceProviderInterface
     public function getFactories()
     {
         return array(
-            'param' => array(SimplexServiceProvider::class, 'getParam'),
+            'param' => array(__CLASS__, 'getParam'),
             'service' => function() {
                 return new Service();
             },
@@ -20,7 +20,7 @@ class SimplexServiceProvider implements ServiceProviderInterface
     public function getExtensions()
     {
         return array(
-            'previous' => array(SimplexServiceProvider::class, 'getPrevious'),
+            'previous' => array(__CLASS__, 'getPrevious'),
         );
     }
 

--- a/src/Simplex/Tests/Fixtures/SimplexServiceProviderWithExtension.php
+++ b/src/Simplex/Tests/Fixtures/SimplexServiceProviderWithExtension.php
@@ -15,12 +15,12 @@ class SimplexServiceProviderWithExtension implements ServiceProviderInterface
     public function getExtensions()
     {
         return array(
-            'test' => function ($container, string $previous) {
+            'test' => function ($container, $previous) {
 
                 return $previous . 'def';
 
             },
-            'extendNothing' => function ($container, string $previous = 'foo') {
+            'extendNothing' => function ($container, $previous = 'foo') {
 
                 return $previous . 'def';
 


### PR DESCRIPTION
Following the addition of Travis, I noticed we previously broke PHP 5 compatibility in the unit tests.

This PR enforces PHP 5 compatibility in the tests again.

Also, the PR adds the Travis badge in the README.